### PR TITLE
Add auto load cookie for lazy loading

### DIFF
--- a/evm-mode.el
+++ b/evm-mode.el
@@ -283,8 +283,8 @@ Highlight the 1st result."
   (run-hooks 'evm-hook))
 
 ;; Binding with *.evm files
-(or (assoc "\\.evm$" auto-mode-alist)
-    (add-to-list 'auto-mode-alist '("\\.evm\\'" . evm-mode)))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.evm\\'" . evm-mode))
 
 ;; Finally export the `evm-mode'
 (provide 'evm-mode)


### PR DESCRIPTION
And remove the needless condition

You need not to check if the value is in the list when using `add-to-list`. Because `add-to-list` checks. Its document says the following.

> Add ELEMENT to the value of LIST-VAR if it isn’t there yet.